### PR TITLE
Add FastAPI health food app example

### DIFF
--- a/docs/docs/how-tos/health_food_app_example.md
+++ b/docs/docs/how-tos/health_food_app_example.md
@@ -1,0 +1,13 @@
+# Health Food App Example
+
+This guide shows how to run a small FastAPI demo that mimics a global health food
+distribution app. The example code lives in `examples/health_food_app/main.py`.
+
+Install the dependencies and start the server:
+
+```bash
+pip install fastapi uvicorn
+uvicorn examples.health_food_app.main:app --reload
+```
+
+Once running, visit `http://localhost:8000/docs` to explore the API.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -289,6 +289,7 @@ nav:
       - Front-end and generative UI:
         - Integrate LangGraph into a React app: cloud/how-tos/use_stream_react.md
         - Implement generative UI with LangGraph: cloud/how-tos/generative_ui_react.md
+        - FastAPI health food app example: how-tos/health_food_app_example.md
 
   - Resources:
     - concepts/faq.md

--- a/examples/health_food_app/main.py
+++ b/examples/health_food_app/main.py
@@ -1,0 +1,67 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI(title="Global Korean Health Food App")
+
+
+class Product(BaseModel):
+    id: int
+    name: str
+    price: float
+    description: str
+
+
+class Order(BaseModel):
+    id: int
+    product_id: int
+    quantity: int
+    address: str
+
+
+# In-memory stores for example purposes
+PRODUCTS = [
+    Product(id=1, name="K-Health Tea", price=10.99, description="Korean herbal tea"),
+    Product(id=2, name="Ginseng Drink", price=15.49, description="Energy booster"),
+    Product(id=3, name="Seaweed Chips", price=4.99, description="Healthy seaweed snack"),
+    Product(id=4, name="Kimchi Pack", price=8.25, description="Traditional fermented cabbage"),
+    Product(id=5, name="Red Ginseng Candy", price=6.00, description="Sweet immune booster"),
+]
+
+ORDERS: List[Order] = []
+
+
+@app.get("/products", response_model=List[Product])
+def list_products() -> List[Product]:
+    """Return the list of available health food products."""
+    return PRODUCTS
+
+
+@app.get("/products/{product_id}", response_model=Product)
+def get_product(product_id: int) -> Product:
+    """Retrieve a product by its ID."""
+    for product in PRODUCTS:
+        if product.id == product_id:
+            return product
+    raise HTTPException(status_code=404, detail="Product not found")
+
+
+@app.post("/orders", response_model=Order)
+def create_order(order: Order) -> Order:
+    """Create a new order for a product."""
+    if not any(p.id == order.product_id for p in PRODUCTS):
+        raise HTTPException(status_code=404, detail="Product not found")
+    ORDERS.append(order)
+    return order
+
+
+@app.get("/orders", response_model=List[Order])
+def list_orders() -> List[Order]:
+    """List all placed orders."""
+    return ORDERS
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add a FastAPI example for a simple health food app
- document how to run the example
- include the new doc in the mkdocs config

## Testing
- `make format` *(fails: unsuccessful tunnel)*
- `make lint` *(fails: unsuccessful tunnel)*
- `make test` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684f8831fe588327b43d4207080c6e7f